### PR TITLE
Fix code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/jobs/headline_scraper_job.rb
+++ b/app/jobs/headline_scraper_job.rb
@@ -5,7 +5,7 @@ class HeadlineScraperJob < ActiveJob::Base
 
   def perform(url:, recipient:)
     headlines = []
-    page = Nokogiri::HTML(open(url))
+    page = Nokogiri::HTML(URI.open(url))
     headlines = page.css("section h1").map(&:text)
     NewsMailer.send_headlines(headlines: headlines, to: recipient)
   end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_9/security/code-scanning/2](https://github.com/Brook-5686/Ruby_9/security/code-scanning/2)

To fix the problem, we should replace the use of `Kernel.open` with a safer alternative. In this case, we can use `URI.open` to open the URL, which is a safer method for handling URLs. Additionally, we should ensure that the `url` parameter is properly validated to prevent any potential security risks.

1. Replace `open(url)` with `URI.open(url)` on line 8.
2. Ensure that the `url` parameter is properly validated before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
