### PR TITLE
Fix code scanning alert no. 1: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,8 +1,8 @@
 class Api::ApiController < ActionController::Base
-  protect_from_forgery with: :null_session
+  protect_from_forgery with: :exception
 
   def self.disable_turbolinks_cookies
-    skip_before_action :set_request_method_cookie
+    # skip_before_action :set_request_method_cookie
   end
 
   disable_turbolinks_cookies


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_9/security/code-scanning/1](https://github.com/Brook-5686/Ruby_9/security/code-scanning/1)

To fix the problem, we should strengthen the CSRF protection by changing the `protect_from_forgery` configuration to raise an exception when an invalid CSRF token is encountered. This can be achieved by using `protect_from_forgery with: :exception` instead of `:null_session`. This change ensures that any request with an invalid CSRF token will be rejected, preventing the action from being executed.

Additionally, we should review the use of `skip_before_action :set_request_method_cookie` to ensure it is necessary and does not introduce security risks. If it is not essential, it should be removed to enhance security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
