### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/pickadate-3.5.5/picker.js
+++ b/app/assets/javascripts/pickadate-3.5.5/picker.js
@@ -780,6 +780,15 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             name = name[0] + ELEMENT.name + name[1]
         }
 
+        function escapeHtml(unsafe) {
+            return unsafe
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
         P._hidden = $(
             '<input ' +
             'type=hidden ' +
@@ -790,7 +799,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             // If the element has a value, set the hidden value as well.
             (
                 $ELEMENT.data('value') || ELEMENT.value ?
-                    ' value="' + P.get('select', SETTINGS.formatSubmit) + '"' :
+                    ' value="' + escapeHtml(P.get('select', SETTINGS.formatSubmit)) + '"' :
                     ''
             ) +
             '>'


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_9/security/code-scanning/3](https://github.com/Brook-5686/Ruby_9/security/code-scanning/3)

To fix the problem, we need to ensure that any data inserted into the HTML string is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a function that escapes HTML special characters before inserting the value into the HTML string. This will ensure that any potentially malicious content is rendered harmless.

We will create a function `escapeHtml` that will escape special characters in the value returned by `P.get('select', SETTINGS.formatSubmit)`. We will then use this function to escape the value before inserting it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
